### PR TITLE
Add support for automatic rotation of secrets in secrets manager

### DIFF
--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -31,6 +31,7 @@ Resources:
               - secretsmanager:DeleteSecret
               - secretsmanager:CreateSecret
               - secretsmanager:UpdateSecret
+              - secretsmanager:RotateSecret
             Resource:
               - '*'
           - Effect: Allow
@@ -71,3 +72,9 @@ Resources:
       Timeout: 30
       Role: !GetAtt 'LambdaRole.Arn'
       Runtime: python3.6
+Outputs:
+  LambdaRoleARN:
+    Value: !GetAtt LambdaRole.Arn
+    Description: ARN of the IAM Role which the custom CFN provider will execute as
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleARN"

--- a/src/cfn_secrets_manager_secret_provider.py
+++ b/src/cfn_secrets_manager_secret_provider.py
@@ -132,7 +132,8 @@ class SecretsManagerSecretProvider(ResourceProvider):
             args = self.create_arguments()
             args['SecretId'] = self.physical_resource_id
             del args['Name']
-            del args['Tags']
+            if 'Tags' in args:
+                del args['Tags']
 
             response = self.sm.update_secret(**args)
             self.set_return_attributes(response)

--- a/src/cfn_secrets_manager_secret_provider.py
+++ b/src/cfn_secrets_manager_secret_provider.py
@@ -101,7 +101,6 @@ class SecretsManagerSecretProvider(ResourceProvider):
         return args
 
     def set_return_attributes(self, response):
-        self.set_attribute('VersionId', response['VersionId'])
         self.physical_resource_id = response['ARN']
         self.no_echo = self.get('NoEcho')
 

--- a/src/cfn_secrets_manager_secret_provider.py
+++ b/src/cfn_secrets_manager_secret_provider.py
@@ -43,6 +43,10 @@ request_schema = {
         "ClientRequestToken": {"type": "string",
                                "description": "a unique identifier for the new version to ensure idempotency"},
         "NoEcho": {"type": "boolean", "default": True, "description": "the secret as output parameter"},
+        "LambdaARN": {"type": "string", "description": "The Lambda used to rotate this secret"},
+        "Interval": {"type": "integer", "minimum": 1, "maximum": 365,
+                     "default": 30,
+                     "description": "Number of days between secret rotations, max: 365"},
         "Tags": {
             "type": "array",
             "items": {
@@ -74,6 +78,8 @@ class SecretsManagerSecretProvider(ResourceProvider):
                 self.properties['NoEcho'] = (self.properties['NoEcho'] == 'true')
             if 'RecoveryWindowInDays' in self.properties:
                 self.properties['RecoveryWindowInDays'] = int(self.properties['RecoveryWindowInDays'])
+            if 'Interval' in self.properties:
+                self.properties['Interval'] = int(self.properties['Interval'])
         except ValueError as e:
             log.error('failed to convert property types %s', e)
 
@@ -99,6 +105,16 @@ class SecretsManagerSecretProvider(ResourceProvider):
         self.physical_resource_id = response['ARN']
         self.no_echo = self.get('NoEcho')
 
+    def set_rotation_config(self):
+        args = {
+            'SecretId': self.get('Name'),
+            'RotationLambdaARN': self.get('LambdaARN'),
+            'RotationRules': {
+                'AutomaticallyAfterDays': self.get('Interval')
+            }
+        }
+        self.sm.rotate_secret(**args)
+
     def create(self):
         try:
             args = self.create_arguments()
@@ -121,6 +137,8 @@ class SecretsManagerSecretProvider(ResourceProvider):
 
             response = self.sm.update_secret(**args)
             self.set_return_attributes(response)
+
+            self.set_rotation_config()
 
             if self.get_old('Tags', self.get('Tags')) != self.get('Tags'):
                 if len(self.get_old('Tags')) > 0:

--- a/src/cfn_secrets_manager_secret_provider.py
+++ b/src/cfn_secrets_manager_secret_provider.py
@@ -105,20 +105,22 @@ class SecretsManagerSecretProvider(ResourceProvider):
         self.no_echo = self.get('NoEcho')
 
     def set_rotation_config(self):
-        args = {
-            'SecretId': self.get('Name'),
-            'RotationLambdaARN': self.get('LambdaARN'),
-            'RotationRules': {
-                'AutomaticallyAfterDays': self.get('Interval')
+        if self.get('LambdaARN') and self.get('Interval'):
+            args = {
+                'SecretId': self.get('Name'),
+                'RotationLambdaARN': self.get('LambdaARN'),
+                'RotationRules': {
+                    'AutomaticallyAfterDays': self.get('Interval')
+                }
             }
-        }
-        self.sm.rotate_secret(**args)
+            self.sm.rotate_secret(**args)
 
     def create(self):
         try:
             args = self.create_arguments()
             response = self.sm.create_secret(**args)
             self.set_return_attributes(response)
+            self.set_rotation_config()
         except ClientError as e:
             self.physical_resource_id = 'could-not-create'
             self.fail('{}'.format(e))


### PR DESCRIPTION
These changes fix #13 by adding two new properties to the SecretsManagerSecret type: LambdaARN and Interval.
It requires the additional permission to rotate a secret (or really to set the rotate secret config).
I've added an output & export of the IAM Role, because the rotation lambda will need to give that IAM role permission to execute the rotation lambda.

