### PR TITLE
Add support for random secret generation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 awscli = "*"
 pytest = "*"
+black = "*"
 
 [packages]
 boto3 = ">=1.5.27"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1a22ef23d8e0ed0c5b2b2c9be5a916d4802ef26ef3a74facbd1731c72e2fab90"
+            "sha256": "1f820a4cd070063110f1f249901123fdfeeb1ceec3fc0e824849e87a0056876b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:055f9dc07f95f202a4dc25196a3a9f1e2f137171ee364cf980e4673de75fb529",
-                "sha256:bc9b278e362ec9b531511a498262297f074c4f5ca9560455919a0af1a4698615"
+                "sha256:3b35689c215c982fe9f7ef78d748aa9b0cd15c3b2eb04f9b460aaa63fe2fbd03",
+                "sha256:b1cbeb92123799001b97f2ee1cdf470e21f1be08314ae28fc7ea357925186f1c"
             ],
             "index": "pypi",
-            "version": "==1.17.104"
+            "version": "==1.17.105"
         },
         "botocore": {
             "hashes": [
-                "sha256:23aa3238c004319f78423eb8cbba2813b62ee64d0e3bab04e0a00e067f99542a",
-                "sha256:95ab472c8254b8d2cfa6d719b433e511fbcf80895b4cd18e4219c1efa0b78270"
+                "sha256:b0fda4edf8eb105453890700d49011ada576d0cc7326a0699dfabe9e872f552c",
+                "sha256:b5ba72d22212b0355f339c2a98b3296b3b2202a48e6a2b1366e866bc65a64b67"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.104"
+            "version": "==1.20.105"
         },
         "certifi": {
             "hashes": [
@@ -259,6 +259,13 @@
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
@@ -269,19 +276,35 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:42dc20b69bf99184ffdd7acd80ee2031f1bbdaec8e7f547dd01fa1b753df41ad",
-                "sha256:461fbdbd9b0593b433cc62f6778afa726b2e9fc4f1b1ad84ad38bb1f3055cfcc"
+                "sha256:41945239477c50784d1faed16e1178c786900230120b9800593f557e6420d622",
+                "sha256:607cb5235dcc273f0ebd9f3cf2a9b808d5e28249d0ed4e96a826151d0ef3d5b0"
             ],
             "index": "pypi",
-            "version": "==1.19.104"
+            "version": "==1.19.105"
+        },
+        "black": {
+            "hashes": [
+                "sha256:dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04",
+                "sha256:dfb8c5a069012b2ab1e972e7b908f5fb42b6bbabcba0a788b86dc05067c7d9c7"
+            ],
+            "index": "pypi",
+            "version": "==21.6b0"
         },
         "botocore": {
             "hashes": [
-                "sha256:23aa3238c004319f78423eb8cbba2813b62ee64d0e3bab04e0a00e067f99542a",
-                "sha256:95ab472c8254b8d2cfa6d719b433e511fbcf80895b4cd18e4219c1efa0b78270"
+                "sha256:b0fda4edf8eb105453890700d49011ada576d0cc7326a0699dfabe9e872f552c",
+                "sha256:b5ba72d22212b0355f339c2a98b3296b3b2202a48e6a2b1366e866bc65a64b67"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.104"
+            "version": "==1.20.105"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
         },
         "colorama": {
             "hashes": [
@@ -315,13 +338,27 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd",
+                "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"
+            ],
+            "version": "==0.8.1"
         },
         "pluggy": {
             "hashes": [
@@ -416,6 +453,52 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==5.4.1"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f",
+                "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad",
+                "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a",
+                "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf",
+                "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59",
+                "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d",
+                "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895",
+                "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4",
+                "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3",
+                "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222",
+                "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0",
+                "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c",
+                "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417",
+                "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d",
+                "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d",
+                "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761",
+                "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0",
+                "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026",
+                "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854",
+                "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb",
+                "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d",
+                "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068",
+                "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde",
+                "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d",
+                "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec",
+                "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa",
+                "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd",
+                "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b",
+                "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26",
+                "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2",
+                "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f",
+                "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694",
+                "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0",
+                "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407",
+                "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874",
+                "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035",
+                "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d",
+                "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c",
+                "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5",
+                "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985",
+                "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"
+            ],
+            "version": "==2021.7.6"
         },
         "rsa": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ or use [![](https://s3.amazonaws.com/cloudformation-examples/cloudformation-laun
 To install the simple sample of the Custom Resource, type:
 
 ```sh
-aws cloudformation create-stack --stack-name cfn-secret-provider-demo \
-       --template-body file://cloudformation/demo-stack.yaml
+aws cloudformation create-stack \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --stack-name cfn-secret-provider-demo \
+    --template-body file://cloudformation/demo-stack.yaml
 aws cloudformation wait stack-create-complete  --stack-name cfn-secret-provider-demo
 ```
 

--- a/cloudformation/demo-stack.yaml
+++ b/cloudformation/demo-stack.yaml
@@ -59,11 +59,10 @@ Resources:
       NoEcho: False
       ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-secret-provider'
 
-  AESKey:
-    Type: Custom::Secret
+  RandomBytes:
+    Type: Custom::RandomBytes
     Properties:
-      Name: !Sub '/${AWS::StackName}/demo/aes-key'
-      Random: true
+      Name: !Sub '/${AWS::StackName}/demo/random'
       Length: 32
       RefreshOnUpdate: false
       ReturnSecret: true
@@ -120,8 +119,8 @@ Outputs:
     Value: !GetAtt 'PrivateKey.Arn'
     Description: ARN of the private key in the Parameter Store
 
-  AESKeyArn:
-    Value: !GetAtt 'AESKey.Arn'
+  RandomBytesArn:
+    Value: !GetAtt 'RandomBytes.Arn'
     Description: ARN of the random key in the Parameter Store
 
   SMTPPassword:

--- a/cloudformation/demo-stack.yaml
+++ b/cloudformation/demo-stack.yaml
@@ -59,6 +59,18 @@ Resources:
       NoEcho: False
       ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-secret-provider'
 
+  AESKey:
+    Type: Custom::Secret
+    Properties:
+      Name: !Sub '/${AWS::StackName}/demo/aes-key'
+      Random: true
+      Length: 32
+      RefreshOnUpdate: false
+      ReturnSecret: true
+      Version: v1
+      NoEcho: False
+      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-secret-provider'
+
   PrivateKey:
     Type: Custom::RSAKey
     Properties:
@@ -107,6 +119,10 @@ Outputs:
   PrivateKeyArn:
     Value: !GetAtt 'PrivateKey.Arn'
     Description: ARN of the private key in the Parameter Store
+
+  AESKeyArn:
+    Value: !GetAtt 'AESKey.Arn'
+    Description: ARN of the random key in the Parameter Store
 
   SMTPPassword:
     Value: !GetAtt 'AccessKey.SMTPPassword'

--- a/docs/RandomBytes.md
+++ b/docs/RandomBytes.md
@@ -1,0 +1,49 @@
+# Custom::RandomBytes
+The `Custom::RandomBytes` resource creates a parameter in the Parameter Store with SecureString value containing a randomized string.
+
+An existing parameter in the Parameter Store will not be overwritten.
+
+## Syntax
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+  Type : Custom::RandomBytes
+  Properties : 
+    Name : String
+    Description : String
+    Length : Integer
+    KeyAlias : String
+    ServiceToken : String
+    RefreshOnUpdate: Boolean
+    ReturnSecret: Boolean
+    Version: String
+```
+
+## Properties
+You can specify the following properties:
+
+- `Name`  - the name of the parameter in the Parameter Store (required)
+- `Description`  - for the parameter in the store. (Default '')
+- `Length`  - the length of the secret in bytes (default `8`)
+- `KeyAlias`  - to use to encrypt the string (default `alias/aws/ssm`)
+- `ReturnSecret`  - as an attribute. (Default 'false')
+- `RefreshOnUpdate`  - generate a new secret on update (Default 'false')
+- `ServiceToken`  - ARN pointing to the lambda function implementing this resource
+- `Version`  - optional, an opaque string to enforce the generation of a new secret.
+- `NoEcho` - indicate whether output of the return values is replaced by `*****`, default True.
+
+## Return values
+With 'Fn::GetAtt' the following values are available:
+
+- `Secret` - the generated secret value base64-encoded, if `ReturnSecret` was set to True.
+- `Arn` - the AWS Resource name of the parameter.
+- `Hash` - of the secret.
+- `Version` - of the value in the store.
+
+### Caveat - Version usage
+Note that the input Version is just an opaque string to force an update of the key if RefreshOnUpdate is true, where
+as the returned Version attribute is the actual version of the parameter value in the store.
+
+For more information about using Fn::GetAtt, see [Fn::GetAtt](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+

--- a/docs/Secret.md
+++ b/docs/Secret.md
@@ -1,6 +1,6 @@
 # Custom::Secret
 The `Custom::Secret` resource creates a parameter in the Parameter Store with SecureString value containing an randomized string. 
-You can also explicit set a value in encrypted format.
+You can also explicitly set a value in encrypted format.
 
 An existing parameter in the Parameter Store will not be overwritten.
 
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   Properties : 
     Name : String
     Description : String
+    Random: Boolean
     Alphabet : String
     Required: 
      - Count: integer
@@ -31,6 +32,7 @@ You can specify the following properties:
 
 - `Name`  - the name of the parameter in the Parameter Store (required)
 - `Description`  - for the parameter in the store. (Default '')
+- `Random`  - generate a random string of `Length` bytes base64-encoded (Default: 'false')
 - `Alphabet` - the alphabet of characters from which to generate a secret (defaults to ASCII letters, digits and punctuation characters)
 - `Required` - an array of required characters and their ccount in the generated secret
 - `Length`  - the length of the secret (default `30`)

--- a/docs/Secret.md
+++ b/docs/Secret.md
@@ -12,7 +12,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   Properties : 
     Name : String
     Description : String
-    Random: Boolean
     Alphabet : String
     Required: 
      - Count: integer
@@ -32,7 +31,6 @@ You can specify the following properties:
 
 - `Name`  - the name of the parameter in the Parameter Store (required)
 - `Description`  - for the parameter in the store. (Default '')
-- `Random`  - generate a random string of `Length` bytes base64-encoded (Default: 'false')
 - `Alphabet` - the alphabet of characters from which to generate a secret (defaults to ASCII letters, digits and punctuation characters)
 - `Required` - an array of required characters and their ccount in the generated secret
 - `Length`  - the length of the secret (default `30`)

--- a/src/cfn_random_bytes_provider.py
+++ b/src/cfn_random_bytes_provider.py
@@ -1,11 +1,8 @@
+import base64
 import binascii
 import hashlib
 import logging
 import os
-import string
-from base64 import b64decode
-from random import choice
-
 
 import boto3
 from botocore.exceptions import ClientError
@@ -33,22 +30,12 @@ request_schema = {
             "default": "",
             "description": "the description of the value in the parameter store",
         },
-        "Alphabet": {
-            "type": "string",
-            "default": string.ascii_letters + string.digits + "_",
-            "description": "the characters from which to generate the secret",
-        },
-        "Required": {
-            "type": "array",
-            "description": "characters in the alphabet",
-            "items": {
-                "type": "object",
-                "required": ["Count", "Alphabet"],
-                "properties": {
-                    "Count": {"type": "integer", "minimum": 1, "default": 1},
-                    "Alphabet": {"type": "string"},
-                },
-            },
+        "Length": {
+            "type": "integer",
+            "description": "length of the random string in bytes",
+            "minimum": 1,
+            "maximum": 512,
+            "default": 8,
         },
         "RefreshOnUpdate": {
             "type": "boolean",
@@ -65,21 +52,6 @@ request_schema = {
             "default": "alias/aws/ssm",
             "description": "KMS key to use to encrypt the value",
         },
-        "Content": {
-            "type": "string",
-            "description": "Plain text secret, to be stored as is.",
-        },
-        "EncryptedContent": {
-            "type": "string",
-            "description": "base64 encoded KMS encrypted secret, decrypted before stored",
-        },
-        "Length": {
-            "type": "integer",
-            "default": 30,
-            "minimum": 1,
-            "maximum": 512,
-            "description": "length of the secret",
-        },
         "Version": {"type": "string", "description": "opaque string to force update"},
         "NoEcho": {
             "type": "boolean",
@@ -90,42 +62,15 @@ request_schema = {
 }
 
 
-class SecretProvider(ResourceProvider):
+class RandomBytesProvider(ResourceProvider):
     def __init__(self):
-        super(SecretProvider, self).__init__()
+        super(RandomBytesProvider, self).__init__()
         self._value = None
         self.request_schema = request_schema
         self.ssm = boto3.client("ssm")
         self.kms = boto3.client("kms")
         self.region = boto3.session.Session().region_name
         self.account_id = (boto3.client("sts")).get_caller_identity()["Account"]
-
-    def is_valid_request(self):
-        result = super(SecretProvider, self).is_valid_request()
-        if (
-            result
-            and "Content" in self.properties
-            and "EncryptedContent" in self.properties
-        ):
-            self.fail('Specify either "Content" or "EncryptedContent"')
-            result = False
-
-        if "EncryptedContent" in self.properties:
-            try:
-                b64decode(self.get("EncryptedContent"))
-            except binascii.Error as e:
-                self.fail("EncryptedContent is not base64 encoded, {}".format(e))
-                result = False
-
-        if result and "Required" in self.properties:
-            required_characters = sum(map(lambda r: r["Count"], self.get("Required")))
-            if required_characters > self.get("Length"):
-                self.fail(
-                    f"the length should at least exceed the {required_characters} required characters"
-                )
-                result = False
-
-        return result
 
     def convert_property_types(self):
         try:
@@ -149,50 +94,22 @@ class SecretProvider(ResourceProvider):
                 self.properties["RefreshOnUpdate"] = (
                     self.properties["RefreshOnUpdate"] == "true"
                 )
-            for a in self.properties.get("Required", []):
-                a["Count"] = int(a["Count"])
         except (binascii.Error, ValueError) as e:
             log.error("failed to convert property types %s", e)
-
-    @property
-    def allow_overwrite(self):
-        return self.physical_resource_id == self.arn
 
     def name_from_physical_resource_id(self):
         return ssm_parameter_name.from_arn(self.physical_resource_id)
 
     @property
+    def allow_overwrite(self):
+        return ssm_parameter_name.equals(self.physical_resource_id, self.arn)
+
+    @property
     def arn(self):
         return ssm_parameter_name.to_arn(self.region, self.account_id, self.get("Name"))
 
-    def generate_password(self):
-        if not self.get("Required"):
-            return "".join(
-                choice(self.get("Alphabet")) for _ in range(0, self.get("Length"))
-            )
-
-        result = []
-        for r in self.get("Required", []):
-            for c in range(r["Count"]):
-                result.append(choice(r["Alphabet"]))
-
-        to_append = self.get("Length") - len(result)
-        result.extend(choice(self.get("Alphabet")) for _ in range(0, to_append))
-
-        return "".join(result)
-
     def get_content(self):
-        if "EncryptedContent" in self.properties:
-            result = self.kms.decrypt(
-                CiphertextBlob=b64decode(self.get("EncryptedContent"))
-            )
-            result = result["Plaintext"].decode("utf8")
-        elif "Content" in self.properties:
-            result = self.get("Content")
-        else:
-            result = self.generate_password()
-
-        return result
+        return base64.b64encode(os.urandom(self.get("Length"))).decode("ascii")
 
     def put_parameter(self, overwrite=False, new_secret=True):
         try:
@@ -243,11 +160,11 @@ class SecretProvider(ResourceProvider):
 
     @property
     def refresh_on_update(self) -> bool:
-        return self.get("RefreshOnUpdate") or self.get("EncryptedContent")
+        return self.get("RefreshOnUpdate")
 
     def update(self):
         self.put_parameter(
-            overwrite=ssm_parameter_name.equals(self.physical_resource_id, self.arn),
+            overwrite=self.allow_overwrite,
             new_secret=self.refresh_on_update,
         )
 
@@ -268,7 +185,7 @@ class SecretProvider(ResourceProvider):
             )
 
 
-provider = SecretProvider()
+provider = RandomBytesProvider()
 
 
 def handler(request, context):

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -8,6 +8,7 @@ import cfn_accesskey_provider
 import cfn_dsakey_provider
 import cfn_read_only_secret_provider
 import cfn_secrets_manager_secret_provider
+import cfn_random_bytes_provider
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 
@@ -25,5 +26,7 @@ def handler(request, context):
         return cfn_secrets_manager_secret_provider.handler(request, context)
     elif request["ResourceType"] == "Custom::ReadOnlySecret":
         return cfn_read_only_secret_provider.handler(request, context)
+    elif request["ResourceType"] == "Custom::RandomBytes":
+        return cfn_random_bytes_provider.handler(request, context)
     else:
         return cfn_secret_provider.handler(request, context)

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -1,5 +1,6 @@
 import os
 import logging
+
 import cfn_secret_provider
 import cfn_rsakey_provider
 import cfn_keypair_provider

--- a/tests/test_cfn_accesskey_provider.py
+++ b/tests/test_cfn_accesskey_provider.py
@@ -116,6 +116,8 @@ def valid_state(request, response):
         assert response["NoEcho"] == True
 
     assert "Hash" in response.get("Data", {})
+
+
 objects = {}
 cfn_deleted = {}
 
@@ -196,8 +198,10 @@ def test_create():
     valid_state(request, new_response)
 
     new_smtp_password = new_response["Data"]["SMTPPassword"]
-    assert response["PhysicalResourceId" ] == new_response["PhysicalResourceId"]
-    assert response["Data"]["SecretAccessKey" ] == new_response["Data"]["SecretAccessKey"]
+    assert response["PhysicalResourceId"] == new_response["PhysicalResourceId"]
+    assert (
+        response["Data"]["SecretAccessKey"] == new_response["Data"]["SecretAccessKey"]
+    )
     assert smtp_password != new_smtp_password
     assert response["Data"]["Hash"] != new_response["Data"]["Hash"]
 

--- a/tests/test_cfn_dsakey_provider.py
+++ b/tests/test_cfn_dsakey_provider.py
@@ -63,12 +63,15 @@ def test_create():
     response = handler(request, {})
     assert response["Status"] == "SUCCESS", response["Reason"]
 
+
 def test_create_1024_key():
     # create a test parameter
     provider = DSAKeyProvider()
     name = "/test/parameter-%s" % uuid.uuid4()
     request = Request("Create", name)
-    request["ResourceProperties"]["Description"] = "the largest private key with openssl public key"
+    request["ResourceProperties"][
+        "Description"
+    ] = "the largest private key with openssl public key"
     request["ResourceProperties"]["KeySize"] = "1024"
     response = provider.handle(request, {})
     assert response["Status"] == "SUCCESS", response["Reason"]


### PR DESCRIPTION
Adds support for random secret generation. The use case for this is e.g. generating the input key for a symmetric encryption cipher like AES.