### PR TITLE
Add posibility to use a PermissionBoundary for the LambdaRole

### DIFF
--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -10,7 +10,6 @@ Parameters:
     Default: 'lambdas/cfn-secret-provider-1.4.4.zip'
   IAMPermissionBoundaryARN:
     Type: String
-    Default: !Ref 'AWS::NoValue'
 Resources:
   LambdaPolicy:
     Type: AWS::IAM::Policy
@@ -49,8 +48,8 @@ Resources:
         - !Ref 'LambdaRole'
   LambdaRole:
     Type: AWS::IAM::Role
-    PermissionsBoundary: !Ref 'IAMPermissionBoundaryARN'
     Properties:
+      PermissionsBoundary: !Ref 'IAMPermissionBoundaryARN'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -10,6 +10,8 @@ Parameters:
     Default: 'lambdas/cfn-secret-provider-1.4.4.zip'
   IAMPermissionBoundaryARN:
     Type: String
+Conditions:
+  HasPermissionBoundary: !Not [!Equals [ !Ref IAMPermissionBoundaryARN, '' ]]
 Resources:
   LambdaPolicy:
     Type: AWS::IAM::Policy
@@ -49,7 +51,7 @@ Resources:
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      PermissionsBoundary: !Ref 'IAMPermissionBoundaryARN'
+      PermissionsBoundary: !If [HasPermissionBoundary, !Ref IAMPermissionBoundaryARN, !Ref 'AWS::NoValue']
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -8,6 +8,9 @@ Parameters:
   CFNCustomProviderZipFileName:
     Type: String
     Default: 'lambdas/cfn-secret-provider-1.4.4.zip'
+  IAMPermissionBoundaryARN:
+    Type: String
+    Default: !Ref 'AWS::NoValue'
 Resources:
   LambdaPolicy:
     Type: AWS::IAM::Policy
@@ -46,6 +49,7 @@ Resources:
         - !Ref 'LambdaRole'
   LambdaRole:
     Type: AWS::IAM::Role
+    PermissionsBoundary: !Ref 'IAMPermissionBoundaryARN'
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'

--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -10,6 +10,7 @@ Parameters:
     Default: 'lambdas/cfn-secret-provider-1.4.4.zip'
   IAMPermissionBoundaryARN:
     Type: String
+    Default: ''
 Conditions:
   HasPermissionBoundary: !Not [!Equals [ !Ref IAMPermissionBoundaryARN, '' ]]
 Resources:


### PR DESCRIPTION
We are in the situation that we only can create roles which adhere to the default boundaries.  
This little MR makes it possible to pass along a policy ARN to be used as PermissionBoundary for the LambdaRole.  
If the Parameter isn't passed along it just won't set the PermissionBoundary on the role.